### PR TITLE
Version bump, new 2021 support

### DIFF
--- a/scanreader/core.py
+++ b/scanreader/core.py
@@ -15,14 +15,17 @@ import re
 from .exceptions import ScanImageVersionError, PathnameError
 from . import scans
 
-_scans = {'5.1': scans.Scan5Point1, '5.2': scans.Scan5Point2, '5.3': scans.Scan5Point3,
+_scans = {
+          '5.1': scans.Scan5Point1, '5.2': scans.Scan5Point2, '5.3': scans.Scan5Point3,
           '5.4': scans.Scan5Point4, '5.5': scans.Scan5Point5, 
           '5.6': scans.Scan5Point6, '5.7': scans.Scan5Point7, 
           '2016b': scans.Scan2016b, 
           '2017a': scans.Scan2017a, '2017b': scans.Scan2017b, 
           '2018a': scans.Scan2018a, '2018b': scans.Scan2018b,
           '2019a': scans.Scan2019a, '2019b': scans.Scan2019b,
-          '2020': scans.Scan2020,}
+          '2020': scans.Scan2020, 
+          '2021': scans.Scan2021
+          }
 
 def read_scan(pathnames, dtype=np.int16, join_contiguous=False):
     """ Reads a ScanImage scan.

--- a/scanreader/scans.py
+++ b/scanreader/scans.py
@@ -21,6 +21,7 @@ BaseScan
                 Scan2019a
                 Scan2019b
                 Scan2020
+                Scan2021
     ScanMultiRoi
 """
 from tifffile import TiffFile
@@ -670,6 +671,114 @@ class Scan2019b(Scan5Point3):
 class Scan2020(Scan5Point3):
     """ ScanImage 2020"""
     pass
+
+class Scan2021(Scan5Point3):
+    """ ScanImage 2021"""
+
+    # New meta data that gets saved into the header when Mini2p unwarping
+    # toolbox was used to correct the data 
+    # 
+    # SI.Custom.MINI2P.MINI2P_Corrected | 'true' or '1' 
+    # SI.Custom.MINI2P.tf_path | str | transformMatrixDirectory
+    # SI.Custom.MINI2P.tfused | str | TransformMatrix_used
+    # SI.Custom.MINI2P.MINI2P_system | str | 
+    # SI.Custom.MINI2P.MINI2P_scope | str |
+    # SI.Custom.MINI2P.MINI2P_objective | str | 
+
+    # Similar entries will be created on the level of the MDF 
+    # transformMatrixDirectory
+    # system
+    # scope
+    # objective
+
+    # @property
+    # @MoserValidation(validated=True)
+    # def is_distortion_corrected(self):
+    #     match = re.search(r"SI.*.MINI2P_Corrected\s*?=\s*?(?P<is_corrected>.*)", string)
+    #     is_corrected = match.group("is_corrected").strip() in ("true", "1")
+    #     return is_corrected
+    @property
+    @MoserValidation(validated=True)
+    def transform_matrix_path(self):
+        ''' 
+        Path of transform matrix object (.mat file)
+        that was used for unwarping (correcting) raw scanimage data
+        '''
+        match = re.search(r'SI.*.tf_path\s*?=\s*?(?P<tf_path>.*)', self.header)
+        if match:
+            path = matlabstr2py(match.group('tf_path').strip())
+            return path
+        else:
+            return None
+
+    @property
+    @MoserValidation(validated=True)
+    def transform_matrix_index(self):
+        ''' 
+        Returns index in (matlab) transform matrix object 
+        (see transform_matrix_path() above)
+        that was used to correct the data. 
+        CAVE! 1-indexing
+        
+        '''
+        match = re.search(r'SI.*.tfused\s*?=\s*?(?P<tfused>.*)', self.header)
+
+        if match:
+            tfused = matlabstr2py(match.group('tfused').strip())
+            return int(tfused)
+        else:
+            return None
+
+    @property
+    @MoserValidation(validated=True)
+    def MINI2P_corrected(self):
+        ''' 
+        Was MINI2P unwarping applied to the data?
+        '''
+        match = re.search(r'SI.*.MINI2P_Corrected\s*?=\s*?(?P<corrected>.*)', self.header)
+
+        if match:
+            corrected = matlabstr2py(match.group('corrected').strip())
+            return corrected in [1, True]
+        else: 
+            return False
+
+    @property
+    @MoserValidation(validated=True)
+    def MINI2P_system(self):
+        # MINI 2P setup (system) name
+        match = re.search(r'SI.*.MINI2P_system\s*?=\s*?(?P<system>.*)', self.header)
+
+        if match:
+            mini2p_system = matlabstr2py(match.group('system').strip())
+            return mini2p_system
+        else: 
+            return None
+
+    @property
+    @MoserValidation(validated=True)
+    def MINI2P_scope(self):
+        # MINI 2P scope name
+        match = re.search(r'SI.*.MINI2P_scope\s*?=\s*?(?P<scope>.*)', self.header)
+
+        if match:
+            mini2p_scope = matlabstr2py(match.group('scope').strip())
+            return mini2p_scope
+        else: 
+            return None
+
+    @property
+    @MoserValidation(validated=True)
+    def MINI2P_objective(self):
+        # MINI 2P objective name
+        match = re.search(r'SI.*.MINI2P_objective\s*?=\s*?(?P<obj>.*)', self.header)
+
+        if match:
+            mini2p_objective = matlabstr2py(match.group('obj').strip())
+            return mini2p_objective
+        else: 
+            return None
+
 
 
 class ScanMultiROI(NewerScan, BaseScan):

--- a/scanreader/scans.py
+++ b/scanreader/scans.py
@@ -677,32 +677,15 @@ class Scan2021(Scan5Point3):
 
     # New meta data that gets saved into the header when Mini2p unwarping
     # toolbox was used to correct the data 
-    # 
-    # SI.Custom.MINI2P.MINI2P_Corrected | 'true' or '1' 
-    # SI.Custom.MINI2P.tf_path | str | transformMatrixDirectory
-    # SI.Custom.MINI2P.tfused | str | TransformMatrix_used
-    # SI.Custom.MINI2P.MINI2P_system | str | 
-    # SI.Custom.MINI2P.MINI2P_scope | str |
-    # SI.Custom.MINI2P.MINI2P_objective | str | 
 
-    # Similar entries will be created on the level of the MDF 
-    # transformMatrixDirectory
-    # system
-    # scope
-    # objective
 
-    # @property
-    # @MoserValidation(validated=True)
-    # def is_distortion_corrected(self):
-    #     match = re.search(r"SI.*.MINI2P_Corrected\s*?=\s*?(?P<is_corrected>.*)", string)
-    #     is_corrected = match.group("is_corrected").strip() in ("true", "1")
-    #     return is_corrected
     @property
     @MoserValidation(validated=True)
-    def transform_matrix_path(self):
+    def MINI2P_transform_matrix_path(self):
         ''' 
         Path of transform matrix object (.mat file)
         that was used for unwarping (correcting) raw scanimage data
+        SI.Custom.MINI2P.tf_path | str | transformMatrixDirectory
         '''
         match = re.search(r'SI.*.tf_path\s*?=\s*?(?P<tf_path>.*)', self.header)
         if match:
@@ -713,12 +696,12 @@ class Scan2021(Scan5Point3):
 
     @property
     @MoserValidation(validated=True)
-    def transform_matrix_index(self):
+    def MINI2P_transform_matrix_index(self):
         ''' 
         Returns index in (matlab) transform matrix object 
         (see transform_matrix_path() above)
         that was used to correct the data. 
-        CAVE! 1-indexing
+        WARNING! 1-indexing
         
         '''
         match = re.search(r'SI.*.tfused\s*?=\s*?(?P<tfused>.*)', self.header)
@@ -734,6 +717,7 @@ class Scan2021(Scan5Point3):
     def MINI2P_corrected(self):
         ''' 
         Was MINI2P unwarping applied to the data?
+        SI.Custom.MINI2P.MINI2P_Corrected | 'true' or '1' 
         '''
         match = re.search(r'SI.*.MINI2P_Corrected\s*?=\s*?(?P<corrected>.*)', self.header)
 
@@ -746,7 +730,9 @@ class Scan2021(Scan5Point3):
     @property
     @MoserValidation(validated=True)
     def MINI2P_system(self):
-        # MINI 2P setup (system) name
+        '''
+        MINI 2P setup (system) name
+        '''
         match = re.search(r'SI.*.MINI2P_system\s*?=\s*?(?P<system>.*)', self.header)
 
         if match:
@@ -758,7 +744,9 @@ class Scan2021(Scan5Point3):
     @property
     @MoserValidation(validated=True)
     def MINI2P_scope(self):
-        # MINI 2P scope name
+        '''
+        MINI 2P scope name
+        '''
         match = re.search(r'SI.*.MINI2P_scope\s*?=\s*?(?P<scope>.*)', self.header)
 
         if match:
@@ -770,7 +758,9 @@ class Scan2021(Scan5Point3):
     @property
     @MoserValidation(validated=True)
     def MINI2P_objective(self):
-        # MINI 2P objective name
+        '''
+        MINI 2P objective name
+        '''
         match = re.search(r'SI.*.MINI2P_objective\s*?=\s*?(?P<obj>.*)', self.header)
 
         if match:

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 from setuptools import setup
 
-long_description = "Python TIFF Stack Reader for ScanImage 5 scans (including multiROI)."
+long_description = "Python TIFF Stack Reader for ScanImage scans (including multiROI)."
 
 setup(
     name='scanreader',
-    version='0.4.12',
-    description="Reader for ScanImage 5 scans (including slow stacks and multiROI).",
+    version='0.4.13',
+    description="Reader for ScanImage scans (including slow stacks and multiROI).",
     long_description=long_description,
     author='Erick Cobos',
     author_email='ecobos@bcm.edu',


### PR DESCRIPTION
Version bump and scanimage 2021 support. 
Features so far not well tested. 

Adds new keywords: 
- `scan.transform_matrix_path`
- `scan.transform_matrix_index`
- `scan.MINI2P_corrected`
- `scan.MINI2P_system` 
- `scan.MINI2P_scope` 
- `scan.MINI2P_objective` 